### PR TITLE
Fix external file watching and add reload command (fixes #8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,4 +71,9 @@ Added support for user home directory and environment variables in `betterReplac
 - **Graceful handling**: Undefined environment variables are left as-is with a warning
 - **Path normalization**: Prevents issues with consecutive slashes in expanded paths
 
-**Known limitation**: File watching is not supported for files outside the workspace root. Reload the window to apply changes to these files.
+## 0.4.1
+
+### Fixed external replacement file reloading
+
+- Automatically reload `replacementsFiles` changes for files outside the workspace root
+- Added `better-replace-on-save.reloadReplacementFiles` for manual config refresh from the command palette

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ Added support for user home directory and environment variables in `betterReplac
 
 ## 0.4.1
 
-### Fixed external replacement file reloading
+### Fix external replacement file reloading
 
 - Automatically reload `replacementsFiles` changes for files outside the workspace root
 - Added `better-replace-on-save.reloadReplacementFiles` for manual config refresh from the command palette

--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ This is particularly useful when you want to apply a replacement regardless of l
 
 ## Release Notes
 
+### 0.4.1
+
+External replacement files outside the workspace root now reload automatically when they change, and there is a new `Reload Replacement Files` command for manual refresh.
+
 ### 0.1.0
 
 Initial release

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ eg.
 
 - `source.applyReplacements` CodeActions provider which can be used in the `editor.codeActionsOnSave` setting
 - Command `better-replace-on-save.applyReplacements` ("Apply Replacements") that can be executed from the command palette
+- Command `better-replace-on-save.reloadReplacementFiles` ("Reload Replacement Files") to refresh settings and external replacement files on demand
 - Language-specific replacements that only apply to files of specified languages
 - Comprehensive settings documentation with VS Code IntelliSense support
 
@@ -84,7 +85,9 @@ You can organize your replacements into separate files to avoid cluttering your 
 - **Variable support (New in 0.4.0)**: Use `~/path`, `${userHome}/path`, `${env:HOME}/path`, `${env:UserProfile}/path`, or `${env:VARIABLE_NAME}/path`
 - Files should contain JSON arrays of replacement objects with the same format as the `replacements` setting
 - External file replacements are merged with settings-based replacements
-- Files are automatically watched for changes and reloaded
+- Files are automatically watched for changes and reloaded, including files outside the workspace root
+
+If you want to force an immediate refresh, run the `Reload Replacement Files` command from the command palette.
 
 **Example paths with variables:**
 ```json
@@ -155,8 +158,6 @@ Support for external replacement files via `betterReplaceOnSave.replacementsFile
 ### 0.4.0
 
 Support for user home directory variables in `betterReplaceOnSave.replacementsFiles`. You can now use `~/path`, `${userHome}/path`, `${env:HOME}/path`, `${env:UserProfile}/path`, or `${env:VARIABLE_NAME}/path` in file paths.
-
-NOTE: *File watch is not supported for files outside the workspace root. Reload the window to apply changes to these files.*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -143,10 +143,6 @@ This is particularly useful when you want to apply a replacement regardless of l
 
 ## Release Notes
 
-### 0.4.1
-
-External replacement files outside the workspace root now reload automatically when they change, and there is a new `Reload Replacement Files` command for manual refresh.
-
 ### 0.1.0
 
 Initial release
@@ -162,6 +158,10 @@ Support for external replacement files via `betterReplaceOnSave.replacementsFile
 ### 0.4.0
 
 Support for user home directory variables in `betterReplaceOnSave.replacementsFiles`. You can now use `~/path`, `${userHome}/path`, `${env:HOME}/path`, `${env:UserProfile}/path`, or `${env:VARIABLE_NAME}/path` in file paths.
+
+### 0.4.1
+
+External replacement files outside the workspace root now reload automatically when they change, and there is a new `Reload Replacement Files` command for manual refresh.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-replace-on-save",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-replace-on-save",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "better-replace-on-save",
   "displayName": "Better Replace-on-Save",
   "description": "Configurable search and replace on save - with proper VSCode integration.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publisher": "maxeonyx",
   "repository": "https://github.com/maxeonyx/better-replace-on-save",
   "icon": "icon.png",
@@ -38,12 +38,12 @@
         "title": "Apply Specific Replacement",
         "category": "Better Replace-on-Save",
         "description": "Apply a single replacement rule by ID, with optional language filter override"
-	      },
-	      {
-	        "command": "better-replace-on-save.reloadReplacementFiles",
-	        "title": "Reload Replacement Files",
-	        "category": "Better Replace-on-Save",
-	        "description": "Reload replacement configuration from settings and external files"
+      },
+      {
+        "command": "better-replace-on-save.reloadReplacementFiles",
+        "title": "Reload Replacement Files",
+        "category": "Better Replace-on-Save",
+        "description": "Reload replacement configuration from settings and external files"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,12 @@
         "title": "Apply Specific Replacement",
         "category": "Better Replace-on-Save",
         "description": "Apply a single replacement rule by ID, with optional language filter override"
+	      },
+	      {
+	        "command": "better-replace-on-save.reloadReplacementFiles",
+	        "title": "Reload Replacement Files",
+	        "category": "Better Replace-on-Save",
+	        "description": "Reload replacement configuration from settings and external files"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as os from 'os';
 
 export interface ReplacementConfig {
-	id?: string;  // Make id optional with ? syntax instead of string | undefined
+	id?: string;
 	search: string;
 	replace: string;
 	languages?: string[];
@@ -177,6 +177,9 @@ function setupFileWatchers(context: vscode.ExtensionContext): void {
 				workspaceWatcher.onDidDelete(reloadReplacements);
 				watcher = workspaceWatcher;
 			} else {
+				// VS Code file watchers only report changes for files inside the workspace.
+				// External replacement files are a supported feature, so use Node's polling
+				// watcher for those paths instead of silently leaving the cache stale.
 				const onFileChange = () => {
 					reloadReplacements();
 				};
@@ -389,7 +392,7 @@ async function applyReplacements(
 				const start = result.index;
 				const end = result.index + result[0].length;
 				const matchedText = text.substring(start, end);
-				const replacementText = matchedText.replace(searchValue, replacement.replace ?? "");
+				const replacementText = matchedText.replace(searchValue, replacement.replace);
 				editBuilder.replace(new vscode.Range(document.positionAt(start), document.positionAt(end)), replacementText);
 			}
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -153,7 +153,7 @@ async function loadAllReplacements(): Promise<ReplacementConfig[]> {
 /**
  * Setup file watchers for replacement files
  */
-function setupFileWatchers(context: vscode.ExtensionContext): void {
+function setupFileWatchers(): void {
 	// Clean up existing watchers
 	fileWatchers.forEach(watcher => watcher.dispose());
 	fileWatchers = [];
@@ -180,7 +180,12 @@ function setupFileWatchers(context: vscode.ExtensionContext): void {
 				// VS Code file watchers only report changes for files inside the workspace.
 				// External replacement files are a supported feature, so use Node's polling
 				// watcher for those paths instead of silently leaving the cache stale.
-				const onFileChange = () => {
+				// Only reload when mtime changes so missing files do not trigger a reload loop.
+				const onFileChange = (curr: fs.Stats, prev: fs.Stats) => {
+					if (curr.mtimeMs === prev.mtimeMs) {
+						return;
+					}
+
 					reloadReplacements();
 				};
 
@@ -191,7 +196,6 @@ function setupFileWatchers(context: vscode.ExtensionContext): void {
 			}
 
 			fileWatchers.push(watcher);
-			context.subscriptions.push(watcher);
 		} catch (error) {
 			console.error(`Better Replace-on-Save: Error setting up file watcher for ${resolvedPath}:`, error);
 		}
@@ -203,7 +207,7 @@ export function activate(context: vscode.ExtensionContext) {
 	void reloadReplacementCache();
 
 	// Setup file watchers
-	setupFileWatchers(context);
+	setupFileWatchers();
 
 	// Watch for configuration changes
 	context.subscriptions.push(
@@ -214,7 +218,7 @@ export function activate(context: vscode.ExtensionContext) {
 				
 				// Re-setup file watchers if replacementsFiles changed
 				if (event.affectsConfiguration('betterReplaceOnSave.replacementsFiles')) {
-					setupFileWatchers(context);
+					setupFileWatchers();
 				}
 			}
 		})

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,8 @@ export { expandVariables };
 
 // Global cache for merged replacements and file watchers
 let cachedReplacements: ReplacementConfig[] = [];
-let fileWatchers: vscode.FileSystemWatcher[] = [];
+let fileWatchers: vscode.Disposable[] = [];
+let reloadGeneration = 0;
 
 /**
  * Expand variables in file paths
@@ -54,21 +55,42 @@ function expandVariables(filePath: string): string {
 	return expandedPath;
 }
 
+function resolveReplacementFilePath(filePath: string): string {
+	let resolvedPath = expandVariables(filePath);
+
+	if (!path.isAbsolute(resolvedPath)) {
+		const workspaceFolders = vscode.workspace.workspaceFolders;
+		if (workspaceFolders && workspaceFolders.length > 0) {
+			resolvedPath = path.join(workspaceFolders[0].uri.fsPath, resolvedPath);
+		}
+	}
+
+	return resolvedPath;
+}
+
+function isWorkspaceFile(filePath: string): boolean {
+	if (!path.isAbsolute(filePath)) {
+		return false;
+	}
+
+	return vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath)) !== undefined;
+}
+
+async function reloadReplacementCache(): Promise<void> {
+	const generation = ++reloadGeneration;
+	const replacements = await loadAllReplacements();
+
+	if (generation === reloadGeneration) {
+		cachedReplacements = replacements;
+	}
+}
+
 /**
  * Load replacements from an external file
  */
 async function loadReplacementsFromFile(filePath: string): Promise<ReplacementConfig[]> {
 	try {
-		// First, expand variables in the file path
-		let resolvedPath = expandVariables(filePath);
-		
-		// Then resolve relative paths relative to workspace root
-		if (!path.isAbsolute(resolvedPath)) {
-			const workspaceFolders = vscode.workspace.workspaceFolders;
-			if (workspaceFolders && workspaceFolders.length > 0) {
-				resolvedPath = path.join(workspaceFolders[0].uri.fsPath, resolvedPath);
-			}
-		}
+		const resolvedPath = resolveReplacementFilePath(filePath);
 
 		// Check if file exists
 		if (!fs.existsSync(resolvedPath)) {
@@ -140,25 +162,30 @@ function setupFileWatchers(context: vscode.ExtensionContext): void {
 	const replacementFiles: string[] = config.get('replacementsFiles') || [];
 
 	for (const filePath of replacementFiles) {
-		// Expand variables and resolve relative paths
-		let resolvedPath = expandVariables(filePath);
-		if (!path.isAbsolute(resolvedPath)) {
-			const workspaceFolders = vscode.workspace.workspaceFolders;
-			if (workspaceFolders && workspaceFolders.length > 0) {
-				resolvedPath = path.join(workspaceFolders[0].uri.fsPath, resolvedPath);
-			}
-		}
+		const resolvedPath = resolveReplacementFilePath(filePath);
 
 		try {
-			const watcher = vscode.workspace.createFileSystemWatcher(resolvedPath);
-			
-			const reloadReplacements = async () => {
-				cachedReplacements = await loadAllReplacements();
+			const reloadReplacements = () => {
+				void reloadReplacementCache();
 			};
 
-			watcher.onDidCreate(reloadReplacements);
-			watcher.onDidChange(reloadReplacements);
-			watcher.onDidDelete(reloadReplacements);
+			let watcher: vscode.Disposable;
+			if (isWorkspaceFile(resolvedPath)) {
+				const workspaceWatcher = vscode.workspace.createFileSystemWatcher(resolvedPath);
+				workspaceWatcher.onDidCreate(reloadReplacements);
+				workspaceWatcher.onDidChange(reloadReplacements);
+				workspaceWatcher.onDidDelete(reloadReplacements);
+				watcher = workspaceWatcher;
+			} else {
+				const onFileChange = () => {
+					reloadReplacements();
+				};
+
+				fs.watchFile(resolvedPath, { interval: 500 }, onFileChange);
+				watcher = new vscode.Disposable(() => {
+					fs.unwatchFile(resolvedPath, onFileChange);
+				});
+			}
 
 			fileWatchers.push(watcher);
 			context.subscriptions.push(watcher);
@@ -170,9 +197,7 @@ function setupFileWatchers(context: vscode.ExtensionContext): void {
 
 export function activate(context: vscode.ExtensionContext) {
 	// Load initial replacements
-	loadAllReplacements().then(replacements => {
-		cachedReplacements = replacements;
-	});
+	void reloadReplacementCache();
 
 	// Setup file watchers
 	setupFileWatchers(context);
@@ -182,7 +207,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.workspace.onDidChangeConfiguration(async (event) => {
 			if (event.affectsConfiguration('betterReplaceOnSave')) {
 				// Reload replacements when configuration changes
-				cachedReplacements = await loadAllReplacements();
+				await reloadReplacementCache();
 				
 				// Re-setup file watchers if replacementsFiles changed
 				if (event.affectsConfiguration('betterReplaceOnSave.replacementsFiles')) {
@@ -252,6 +277,12 @@ export function activate(context: vscode.ExtensionContext) {
 			// When called from on-save code action, isCodeAction will be true (passed by CodeActionProvider)
 			// When called directly from command palette, isCodeAction will be undefined or false
 			await applyReplacements(editor, replacementId, !!isCodeAction);
+		})
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand('better-replace-on-save.reloadReplacementFiles', async () => {
+			await reloadReplacementCache();
+			vscode.window.showInformationMessage('Reloaded Better Replace-on-Save replacement files.');
 		})
 	);
 }
@@ -340,12 +371,19 @@ async function applyReplacements(
 		const text = document.getText();
 
 		for (const replacement of applicableReplacements) {
-			if (replacement.search === undefined) {
-				console.warn(`Better Replace-on-Save: Missing search pattern for replacement`, replacement);
+			if (replacement.search === undefined || replacement.replace === undefined) {
+				console.warn(`Better Replace-on-Save: Missing search or replace value for replacement`, replacement);
 				continue;
 			}
 
-			const searchValue = new RegExp(replacement.search, 'gd');
+			let searchValue: RegExp;
+			try {
+				searchValue = new RegExp(replacement.search, 'gd');
+			} catch (error) {
+				console.warn(`Better Replace-on-Save: Invalid search pattern: ${replacement.search}`, error);
+				continue;
+			}
+
 			const results = text.matchAll(searchValue);
 			for (const result of results) {
 				const start = result.index;
@@ -358,4 +396,7 @@ async function applyReplacements(
 	}));
 }
 
-export function deactivate() { }
+export function deactivate() {
+	fileWatchers.forEach(watcher => watcher.dispose());
+	fileWatchers = [];
+}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -590,10 +590,9 @@ suite('Extension Test Suite', () => {
 				const doc = await createTestFile('replfiles-reload-command-updated.testfile.txt', 'gamma');
 
 				await vscode.commands.executeCommand('better-replace-on-save.reloadReplacementFiles');
-				const reloadedDoc = await vscode.workspace.openTextDocument(doc.uri);
-				await vscode.window.showTextDocument(reloadedDoc);
+				await vscode.window.showTextDocument(doc);
 				await vscode.commands.executeCommand('better-replace-on-save.applyReplacements');
-				await assertReplacement(reloadedDoc, 'delta');
+				await assertReplacement(doc, 'delta');
 			} finally {
 				await fs.rm(tempDir, { recursive: true, force: true });
 			}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -64,6 +64,23 @@ suite('Extension Test Suite', () => {
 		assert.strictEqual(content, expected, message);
 	}
 
+	async function eventually(assertion: () => Promise<void>, timeoutMs: number = 5000, intervalMs: number = 100): Promise<void> {
+		const deadline = Date.now() + timeoutMs;
+		let lastError: unknown;
+
+		while (Date.now() < deadline) {
+			try {
+				await assertion();
+				return;
+			} catch (error) {
+				lastError = error;
+				await new Promise(resolve => setTimeout(resolve, intervalMs));
+			}
+		}
+
+		throw lastError;
+	}
+
 	// Test execution methods to reuse common patterns
 	async function runCommandOnFile(fileName: string, initialContent: string, command: string, ...args: any[]): Promise<vscode.TextDocument> {
 		const doc = await createTestFile(fileName, initialContent);
@@ -472,6 +489,111 @@ suite('Extension Test Suite', () => {
 			);
 
 			await assertReplacement(doc, 'This is loaded content');
+		});
+
+		test('Load replacements from an absolute file path outside the workspace', async () => {
+			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'better-replace-on-save-outside-workspace-'));
+			const outsideWorkspaceFilePath = path.join(tempDir, 'outside-workspace-replacements.json');
+
+			try {
+				await fs.writeFile(outsideWorkspaceFilePath, JSON.stringify([
+					{
+						search: 'outside',
+						replace: 'loaded'
+					}
+				], null, 2), 'utf-8');
+
+				await configureReplacementFiles([outsideWorkspaceFilePath]);
+
+				const doc = await runCommandOnFile(
+					'replfiles-outside-workspace-load.testfile.txt',
+					'This is outside content',
+					'better-replace-on-save.applyReplacements'
+				);
+
+				await assertReplacement(doc, 'This is loaded content');
+			} finally {
+				await fs.rm(tempDir, { recursive: true, force: true });
+			}
+		});
+
+		test('Refreshing an out-of-workspace replacement file updates cached replacements automatically', async () => {
+			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'better-replace-on-save-auto-reload-'));
+			const outsideWorkspaceFilePath = path.join(tempDir, 'outside-workspace-replacements.json');
+
+			try {
+				await fs.writeFile(outsideWorkspaceFilePath, JSON.stringify([
+					{
+						search: 'before',
+						replace: 'after'
+					}
+				], null, 2), 'utf-8');
+
+				await configureReplacementFiles([outsideWorkspaceFilePath]);
+
+				const initialDoc = await runCommandOnFile(
+					'replfiles-outside-workspace-initial.testfile.txt',
+					'before',
+					'better-replace-on-save.applyReplacements'
+				);
+				await assertReplacement(initialDoc, 'after');
+
+				await fs.writeFile(outsideWorkspaceFilePath, JSON.stringify([
+					{
+						search: 'second',
+						replace: 'updated'
+					}
+				], null, 2), 'utf-8');
+
+				const doc = await createTestFile('replfiles-outside-workspace-refresh.testfile.txt', 'second');
+
+				await eventually(async () => {
+					await vscode.window.showTextDocument(doc);
+					await vscode.commands.executeCommand('better-replace-on-save.applyReplacements');
+					await assertReplacement(doc, 'updated');
+				});
+			} finally {
+				await fs.rm(tempDir, { recursive: true, force: true });
+			}
+		});
+
+		test('Reload replacement files command refreshes an out-of-workspace replacement file on demand', async () => {
+			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'better-replace-on-save-manual-reload-'));
+			const outsideWorkspaceFilePath = path.join(tempDir, 'outside-workspace-replacements.json');
+
+			try {
+				await fs.writeFile(outsideWorkspaceFilePath, JSON.stringify([
+					{
+						search: 'alpha',
+						replace: 'beta'
+					}
+				], null, 2), 'utf-8');
+
+				await configureReplacementFiles([outsideWorkspaceFilePath]);
+
+				const initialDoc = await runCommandOnFile(
+					'replfiles-reload-command-initial.testfile.txt',
+					'alpha',
+					'better-replace-on-save.applyReplacements'
+				);
+				await assertReplacement(initialDoc, 'beta');
+
+				await fs.writeFile(outsideWorkspaceFilePath, JSON.stringify([
+					{
+						search: 'gamma',
+						replace: 'delta'
+					}
+				], null, 2), 'utf-8');
+
+				const doc = await createTestFile('replfiles-reload-command-updated.testfile.txt', 'gamma');
+
+				await vscode.commands.executeCommand('better-replace-on-save.reloadReplacementFiles');
+				await vscode.window.showTextDocument(doc);
+				await vscode.commands.executeCommand('better-replace-on-save.applyReplacements');
+				await assertReplacement(doc, 'delta');
+			} finally {
+				await fs.rm(tempDir, { recursive: true, force: true });
+			}
 		});
 
 		test('Merge settings and file-based replacements', async () => {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -517,7 +517,9 @@ suite('Extension Test Suite', () => {
 			}
 		});
 
-		test('Refreshing an out-of-workspace replacement file updates cached replacements automatically', async () => {
+		test('Refreshing an out-of-workspace replacement file updates cached replacements automatically', async function () {
+			this.timeout(10000);
+
 			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'better-replace-on-save-auto-reload-'));
 			const outsideWorkspaceFilePath = path.join(tempDir, 'outside-workspace-replacements.json');
 
@@ -588,9 +590,10 @@ suite('Extension Test Suite', () => {
 				const doc = await createTestFile('replfiles-reload-command-updated.testfile.txt', 'gamma');
 
 				await vscode.commands.executeCommand('better-replace-on-save.reloadReplacementFiles');
-				await vscode.window.showTextDocument(doc);
+				const reloadedDoc = await vscode.workspace.openTextDocument(doc.uri);
+				await vscode.window.showTextDocument(reloadedDoc);
 				await vscode.commands.executeCommand('better-replace-on-save.applyReplacements');
-				await assertReplacement(doc, 'delta');
+				await assertReplacement(reloadedDoc, 'delta');
 			} finally {
 				await fs.rm(tempDir, { recursive: true, force: true });
 			}


### PR DESCRIPTION
## Problem
Out-of-workspace replacement files (configured via `replacementsFiles`) are loaded once at activation but never refreshed. `vscode.workspace.createFileSystemWatcher` only fires events for files inside a workspace folder, so changes to external config files (e.g. in dotfiles or home directories) are silently ignored until the user reloads the entire window.

## Solution
- Add Node.js `fs.watch()` fallback for replacement files that resolve outside any workspace folder
- Add a `Reload Replacement Files` command for manual refresh
- Keep existing `createFileSystemWatcher` for in-workspace files (it works correctly there)

Fixes #8